### PR TITLE
Version 0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change log
 
+## Version 0.4 (Jul 12, 2020 JST)
+
+- corrected disassemble log of following:
+  - `AND R, (IX+d)`
+  - `AND R, (IY+d)`
+  - `OR R, (RP)`
+  - `OR R, (IX+d)`
+  - `OR R, (IY+d)`
+  - `XOR R, (RP)`
+  - `XOR R, (IX+d)`
+  - `XOR R, (IY+d)`
+
 ## Version 0.3 (Sept 8, 2019 JST)
 
 - support multiple break operands (Destructive change)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.4 (Jul 12, 2020 JST)
 
+- added an explicit execution break function (requestBreak)
 - corrected disassemble log of following:
   - `AND R, (IX+d)`
   - `AND R, (IY+d)`

--- a/test-result.txt
+++ b/test-result.txt
@@ -133,18 +133,18 @@
 [016E] AND A<$77>, B<$AB>
 [016F] AND A<$23>, $AA
 [0171] AND A<$22>, (HL<$FFFD>) = $00
-[0172] AND A<$00>, (IX+d<$ECA2>) = $10
-[0175] AND A<$00>, (IY+d<$ECC2>) = $10
+[0172] AND A<$00>, (IX+d<$ECA2>) = $00
+[0175] AND A<$00>, (IY+d<$ECC2>) = $00
 [0178] OR A<$00>, B<$AB>
 [0179] OR A<$AB>, $AA
-[017B] OR A<$AB>, (HL<$FFFD>) = $00
-[017C] OR A<$AB>, (IX+d<$ECA2>) = $10
-[017F] OR A<$AB>, (IY+d<$ECC2>) = $10
+[017B] OR A<$AB>, (HL<$FFFD>) = $AB
+[017C] OR A<$AB>, (IX+d<$ECA2>) = $AB
+[017F] OR A<$AB>, (IY+d<$ECC2>) = $AB
 [0182] XOR A<$AB>, B<$AB>
 [0183] XOR A<$00>, $AA
-[0185] XOR A<$AA>, (HL<$FFFD>) = $00
-[0186] XOR A<$AA>, (IX+d<$ECA2>) = $10
-[0189] XOR A<$AA>, (IY+d<$ECC2>) = $10
+[0185] XOR A<$AA>, (HL<$FFFD>) = $AA
+[0186] XOR A<$AA>, (IX+d<$ECA2>) = $AA
+[0189] XOR A<$AA>, (IY+d<$ECC2>) = $AA
 [018C] CPL A<$AA>
 [018D] NEG A<$55>
 [018F] CCF <C:OFF -> ON>

--- a/test.cpp
+++ b/test.cpp
@@ -172,6 +172,23 @@ int main(int argc, char* argv[])
     z80.reg.pair.L = 0x01;
     z80.reg.IY = 1;
 
+    /*
+    // requestBreak test
+    puts("==== REQUEST BREAK ====");
+    z80.reg.PC = 0x0;
+    z80.reg.consumeClockCounter = 0;
+    static int totalClocks = 0;
+    z80.setConsumeClockCallback([](void* arg, int clocks) {
+        totalClocks += clocks;
+        if (100 <= totalClocks) {
+            puts("require break");
+            ((MMU*)arg)->cpu->requestBreak();
+        }
+    });
+    printf("executed %d Hz\n", z80.execute(0xFFFFFF));
+    exit(0);
+    */
+
     if (autoExec) {
         // 通常は面倒なのでNOPを検出するまで実行し続ける
         while (0 < z80.executeTick4MHz()) {

--- a/z80.hpp
+++ b/z80.hpp
@@ -26,11 +26,11 @@
  */
 #ifndef INCLUDE_Z80_HPP
 #define INCLUDE_Z80_HPP
+#include <limits.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
 #include <string.h>
-#include <limits.h>
 #include <time.h>
 #include <vector>
 
@@ -2732,7 +2732,7 @@ class Z80
         signed char d = CB.read(CB.arg, reg.PC + 2);
         unsigned short addr = reg.IX + d;
         unsigned char n = CB.read(CB.arg, addr);
-        log("[%04X] AND %s, (IX+d<$%04X>) = $%02X", reg.PC, registerDump(0b111), addr);
+        log("[%04X] AND %s, (IX+d<$%04X>) = $%02X", reg.PC, registerDump(0b111), addr, reg.pair.A & n);
         reg.pair.A &= n;
         setFlagByLogical();
         reg.PC += 3;
@@ -2745,7 +2745,7 @@ class Z80
         signed char d = CB.read(CB.arg, reg.PC + 2);
         unsigned short addr = reg.IY + d;
         unsigned char n = CB.read(CB.arg, addr);
-        log("[%04X] AND %s, (IY+d<$%04X>) = $%02X", reg.PC, registerDump(0b111), addr);
+        log("[%04X] AND %s, (IY+d<$%04X>) = $%02X", reg.PC, registerDump(0b111), addr, reg.pair.A & n);
         reg.pair.A &= n;
         setFlagByLogical();
         reg.PC += 3;
@@ -2783,7 +2783,7 @@ class Z80
     {
         unsigned short addr = ctx->getHL();
         unsigned char n = ctx->CB.read(ctx->CB.arg, addr);
-        ctx->log("[%04X] OR %s, (%s) = $%02X", ctx->reg.PC, ctx->registerDump(0b111), ctx->registerPairDump(0b10), n);
+        ctx->log("[%04X] OR %s, (%s) = $%02X", ctx->reg.PC, ctx->registerDump(0b111), ctx->registerPairDump(0b10), ctx->reg.pair.A | n);
         ctx->reg.pair.A |= n;
         ctx->setFlagByLogical();
         ctx->reg.PC++;
@@ -2796,7 +2796,7 @@ class Z80
         signed char d = CB.read(CB.arg, reg.PC + 2);
         unsigned short addr = reg.IX + d;
         unsigned char n = CB.read(CB.arg, addr);
-        log("[%04X] OR %s, (IX+d<$%04X>) = $%02X", reg.PC, registerDump(0b111), addr);
+        log("[%04X] OR %s, (IX+d<$%04X>) = $%02X", reg.PC, registerDump(0b111), addr, reg.pair.A | n);
         reg.pair.A |= n;
         setFlagByLogical();
         reg.PC += 3;
@@ -2809,7 +2809,7 @@ class Z80
         signed char d = CB.read(CB.arg, reg.PC + 2);
         unsigned short addr = reg.IY + d;
         unsigned char n = CB.read(CB.arg, addr);
-        log("[%04X] OR %s, (IY+d<$%04X>) = $%02X", reg.PC, registerDump(0b111), addr);
+        log("[%04X] OR %s, (IY+d<$%04X>) = $%02X", reg.PC, registerDump(0b111), addr, reg.pair.A | n);
         reg.pair.A |= n;
         setFlagByLogical();
         reg.PC += 3;
@@ -2847,7 +2847,7 @@ class Z80
     {
         unsigned short addr = ctx->getHL();
         unsigned char n = ctx->CB.read(ctx->CB.arg, addr);
-        ctx->log("[%04X] XOR %s, (%s) = $%02X", ctx->reg.PC, ctx->registerDump(0b111), ctx->registerPairDump(0b10), n);
+        ctx->log("[%04X] XOR %s, (%s) = $%02X", ctx->reg.PC, ctx->registerDump(0b111), ctx->registerPairDump(0b10), ctx->reg.pair.A ^ n);
         ctx->reg.pair.A ^= n;
         ctx->setFlagByLogical();
         ctx->reg.PC++;
@@ -2860,7 +2860,7 @@ class Z80
         signed char d = CB.read(CB.arg, reg.PC + 2);
         unsigned short addr = reg.IX + d;
         unsigned char n = CB.read(CB.arg, addr);
-        log("[%04X] XOR %s, (IX+d<$%04X>) = $%02X", reg.PC, registerDump(0b111), addr);
+        log("[%04X] XOR %s, (IX+d<$%04X>) = $%02X", reg.PC, registerDump(0b111), addr, reg.pair.A ^ n);
         reg.pair.A ^= n;
         setFlagByLogical();
         reg.PC += 3;
@@ -2873,7 +2873,7 @@ class Z80
         signed char d = CB.read(CB.arg, reg.PC + 2);
         unsigned short addr = reg.IY + d;
         unsigned char n = CB.read(CB.arg, addr);
-        log("[%04X] XOR %s, (IY+d<$%04X>) = $%02X", reg.PC, registerDump(0b111), addr);
+        log("[%04X] XOR %s, (IY+d<$%04X>) = $%02X", reg.PC, registerDump(0b111), addr, reg.pair.A ^ n);
         reg.pair.A ^= n;
         setFlagByLogical();
         reg.PC += 3;

--- a/z80.hpp
+++ b/z80.hpp
@@ -117,6 +117,8 @@ class Z80
         void* arg;
     } CB;
 
+    bool requestBreakFlag;
+
     inline void checkBreakPoint()
     {
         if (!CB.breakPoints.empty()) {
@@ -4115,10 +4117,16 @@ class Z80
         CB.consumeClock = consumeClock;
     }
 
+    void requestBreak()
+    {
+        requestBreakFlag = true;
+    }
+
     int execute(int clock)
     {
         int executed = 0;
-        while (0 < clock && !reg.isHalt) {
+        requestBreakFlag = false;
+        while (0 < clock && !reg.isHalt && !requestBreakFlag) {
             checkBreakPoint();
             int operandNumber = CB.read(CB.arg, reg.PC);
             checkBreakOperand(operandNumber);
@@ -4187,7 +4195,7 @@ class Z80
             executed += consume;
         }
         // execute NOP while halt
-        while (0 < clock && reg.isHalt) {
+        while (0 < clock && reg.isHalt && !requestBreakFlag) {
             checkBreakPoint();
             checkBreakOperand(0);
             // execute program counter & consume 4Hz (same as NOP)


### PR DESCRIPTION
- added an explicit execution break function (requestBreak)
- corrected disassemble log

### requestBreakに関する補足

エミュレータは概ね、以下の処理の繰り返しで実行する:

1. 1フレーム分のエミュレーション実行
2. エミュレーション環境の出力機器への出力

1フレーム（NTSCなら1/60秒、PALなら1/50秒）の実行クロック数が割り切れる値であることはほぼ無いので、多くのエミュレータではVBLANK開始NMI等のタイミングでエミュレーション処理実行を明示的に中断するので、requestBreakがあると実装が捗る。