### PR TITLE
bugfix: OUT (C), r will unknown instruction error in the SEGA old hardware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## Version 0.5 (Jul 12, 2020 JST)
+
+- implemented compatible(?) instructions:
+  - `OUT (C), r`
+
 ## Version 0.4 (Jul 12, 2020 JST)
 
 - added an explicit execution break function (requestBreak)

--- a/z80.hpp
+++ b/z80.hpp
@@ -438,6 +438,9 @@ class Z80
             case 0b01000000: return ctx->IN_R_C((mode & 0b00110000) >> 4);
             case 0b01000001: return ctx->OUT_C_R((mode & 0b00110000) >> 4);
         }
+        if ((mode & 0b11000111) == 0b01000001) {
+            return ctx->OUT_C_R((mode & 0b00111000) >> 3);
+        }
         ctx->log("unknown EXTRA: $%02X", mode);
         return -1;
     }


### PR DESCRIPTION
As a program running on old Sega hardware caused an unknown instruction error due to the following instruction execution, take measures.

```
ED41
ED49
ED51
ED59
ED61
ED69
ED79
``