### PR TITLE
Fixed a bug that IRQ/NMI request flag does not clear when masked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## Version 0.8 (Jul 16, 2020 JST)
+
+- Fixed a bug that IRQ/NMI request flag does not clear when masked
+
 ## Version 0.7 (Jul 16, 2020 JST)
 
 - Fixed a bug that DJNZ command does not work properly:

--- a/z80.hpp
+++ b/z80.hpp
@@ -4063,7 +4063,10 @@ class Z80
         // check interrupt flag
         if (reg.interrupt & 0b10000000) {
             // execute NMI
-            if (reg.IFF & IFF_NMI()) return;
+            if (reg.IFF & IFF_NMI()) {
+                reg.interrupt &= 0b00111111; // clear request flags
+                return;
+            }
             log("EXECUTE NMI: $%04X", reg.interruptAddrN);
             reg.R++;
             reg.IFF |= IFF_NMI();
@@ -4077,7 +4080,10 @@ class Z80
             consumeClock(11);
         } else if (reg.interrupt & 0b01000000) {
             // execute IRQ
-            if (!(reg.IFF & IFF1())) return;
+            if (!(reg.IFF & IFF1())) {
+                reg.interrupt &= 0b00111111; // clear request flags
+                return;
+            }
             reg.IFF |= IFF_IRQ();
             reg.IFF &= ~(IFF1() | IFF2());
             switch (reg.interrupt & 0b00000011) {


### PR DESCRIPTION
When I implemented the emulator and verified it, IRQ/NMI whose execution was masked disappeared at that point, so I will fix it as such.