### PR TITLE
Version 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## Version 1.1.1 (Jul 29, 2020 JST)
+
+- bugfix: R register not increment after executed opcode.
+
 ## Version 1.1.0 (Jul 27, 2020 JST)
 
 - enhancement: implement undocumented instructions:

--- a/z80.hpp
+++ b/z80.hpp
@@ -5019,6 +5019,7 @@ class Z80
             executed += reg.consumeClockCounter;
             clock -= reg.consumeClockCounter;
             reg.consumeClockCounter = 0;
+            reg.R = ((reg.R + 1) & 0x7F) | (reg.R & 0x80);
             checkInterrupt();
         }
         return executed;

--- a/z80.hpp
+++ b/z80.hpp
@@ -4783,7 +4783,7 @@ class Z80
             reg.interrupt &= 0b01111111;
             reg.IFF &= ~IFF_HALT();
             if (isDebug()) log("EXECUTE NMI: $%04X", reg.interruptAddrN);
-            reg.R++;
+            reg.R = ((reg.R + 1) & 0x7F) | (reg.R & 0x80);
             reg.IFF |= IFF_NMI();
             reg.IFF &= ~IFF1();
             unsigned char pcL = reg.PC & 0x00FF;
@@ -4802,6 +4802,7 @@ class Z80
             reg.IFF &= ~IFF_HALT();
             reg.IFF |= IFF_IRQ();
             reg.IFF &= ~(IFF1() | IFF2());
+            reg.R = ((reg.R + 1) & 0x7F) | (reg.R & 0x80);
             switch (reg.interrupt & 0b00000011) {
                 case 0: // mode 0
                     if (isDebug()) log("EXECUTE INT MODE1 (RST TO $%04X)", reg.interruptVector * 8);


### PR DESCRIPTION
- bugfix: R register not increment after executed opcode.
- bugfix: R will over 127 if execute NMI 128 times
