### PR TITLE
bugfix: NMI will not generate after 2nd times or later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## Version 1.2.1 (Aug 4, 2020 JST)
+
+- bugfix: NMI will not generate after 2nd times or later (NMI flag did not clear by RETN)
+
 ## Version 1.2.0 (Jul 30, 2020 JST)
 
 - support LR35902 (GBZ80) compatible mode

--- a/z80.hpp
+++ b/z80.hpp
@@ -4478,6 +4478,7 @@ class Z80
         reg.SP += 2;
         reg.PC = addr;
         reg.WZ = addr;
+        reg.IFF &= ~IFF_NMI();
         if (!((reg.IFF & IFF1()) && (reg.IFF & IFF2()))) {
             reg.IFF |= IFF1();
         } else {


### PR DESCRIPTION
NMI flag did not clear by RETN.
_This bug was detected while making SEGA Master System emulator (PAUSE button feature)._