### PR TITLE
Version 1.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## Version 1.2.7 (Nov 30, 2021 JST)
+
+- bugfix: memory leak when using `addBreakOperand`, `addBreakPoint`, `addCallHandler` or `addReturnHandler`, and not remove them
+
 ## Version 1.2.6 (Nov 30, 2021 JST)
 
 - Make the `readByte` and `writeByte` methods public instead of private for allow external programs to read and write memory via the CPU (synchronously). 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## Version 1.2.7 (Nov 30, 2021 JST)
+## Version 1.2.7 (Dec 1, 2021 JST)
 
 - bugfix: memory leak when using `addBreakOperand`, `addBreakPoint`, `addCallHandler` or `addReturnHandler`, and not remove them
 

--- a/z80.hpp
+++ b/z80.hpp
@@ -5088,7 +5088,13 @@ class Z80
         setupOpSet1();
     }
 
-    ~Z80() {}
+    ~Z80()
+    {
+        removeAllBreakOperands();
+        removeAllBreakPoints();
+        removeAllCallHandlers();
+        removeAllReturnHandlers();
+    }
 
     void setDebugMessage(void (*debugMessage)(void*, const char*) = NULL)
     {


### PR DESCRIPTION
- [x] bugfix: memory leak when using `addBreakOperand`, `addBreakPoint`, `addCallHandler` or `addReturnHandler`, and not remove them