### PR TITLE
Version 1.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-script:
-  - make

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## Version 1.5.0 (Spt 6, 2022 JST)
+
+- Implemented several undocumented instructions of ED instruction set.
+- bugfix: `IN F, (C)` -> `IN (C)`
+- bugfix: `OUT (C), F` -> `OUT (C),0`
+
 ## Version 1.4.0 (Spt 4, 2022 JST)
 
 - Pull Request: #35

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## Version 1.5.0 (Spt 6, 2022 JST)
+## Version 1.5.0 (Spt 11, 2022 JST)
 
 - Implemented several undocumented instructions of ED instruction set.
 - bugfix: Corrected opcode `ED70` behavior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 ## Version 1.5.0 (Spt 6, 2022 JST)
 
 - Implemented several undocumented instructions of ED instruction set.
-- bugfix: `IN F, (C)` -> `IN (C)`
-- bugfix: `OUT (C), F` -> `OUT (C),0`
+- bugfix: Corrected opcode `ED70` behavior
+  - `IN F, (C)` -> `IN (C)`
+- bugfix: Corrected opcode `ED71` behavior
+  - `OUT (C), F` -> `OUT (C),0`
+
 
 ## Version 1.4.0 (Spt 4, 2022 JST)
 

--- a/test-ex/cpm.cpp
+++ b/test-ex/cpm.cpp
@@ -144,12 +144,13 @@ int main(int argc, char* argv[])
     };
     char animePattern[] = { '/', '-', '\\', '|' };
     int anime = 0;
+    unsigned long totalClocks = 0;
     do {
-        z80.execute(35795450); // 10sec in Z80A
+        totalClocks += z80.execute(35795450); // 10sec in Z80A
         if (cpm.error) {
             printf("\rCPM detected an error at $%04X\n", z80.reg.PC);
         } else if (cpm.halted) {
-            printf("CPM halted at $%04X\n", z80.reg.PC);
+            printf("CPM halted at $%04X (total: %luHz ... about %lu seconds in Z80A)\n", z80.reg.PC, totalClocks, totalClocks / 3579545);
         } else if (!noAnimation) {
             putc(animePattern[anime++], stdout);
             anime &= 3;

--- a/test/test-clock.txt
+++ b/test/test-clock.txt
@@ -423,5 +423,5 @@ TEST#380: 23Hz [0000] SET (IX+d<$7BF6>) = $0F of bit-4 --> B<$0F>
 TEST#381: 23Hz [0000] SET (IX+d<$7BF6>) = $1F of bit-5 --> B<$1F>
 TEST#382: 23Hz [0000] SET (IX+d<$7BF6>) = $3F of bit-6 --> B<$3F>
 TEST#383: 23Hz [0000] SET (IX+d<$7BF6>) = $7F of bit-7 --> B<$7F>
-TEST#384: 12Hz [0000] IN F<$45>, (C<$01>) = $00
-TEST#385: 12Hz [0000] OUT (C<$01>), F<$44>
+TEST#384: 12Hz [0000] IN (C<$01>) = $00
+TEST#385: 12Hz [0000] OUT (C<$01>), 0

--- a/z80.hpp
+++ b/z80.hpp
@@ -354,8 +354,8 @@ class Z80
     inline unsigned short getRPIX(unsigned char rp)
     {
         switch (rp & 0b11) {
-            case 0b00: return (reg.pair.B << 8) + reg.pair.C;
-            case 0b01: return (reg.pair.D << 8) + reg.pair.E;
+            case 0b00: return getBC();
+            case 0b01: return getDE();
             case 0b10: return reg.IX;
             default: return reg.SP;
         }
@@ -364,8 +364,8 @@ class Z80
     inline unsigned short getRPIY(unsigned char rp)
     {
         switch (rp & 0b11) {
-            case 0b00: return (reg.pair.B << 8) + reg.pair.C;
-            case 0b01: return (reg.pair.D << 8) + reg.pair.E;
+            case 0b00: return getBC();
+            case 0b01: return getDE();
             case 0b10: return reg.IY;
             default: return reg.SP;
         }


### PR DESCRIPTION
- Implemented several undocumented instructions of ED instruction set.
- bugfix: Corrected opcode `ED70` behavior
  - `IN F, (C)` -> `IN (C)`
- bugfix: Corrected opcode `ED71` behavior
  - `OUT (C), F` -> `OUT (C),0`
