### PR TITLE
Add compile flags for performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - `-DZ80_DISABLE_BREAKPOINT` ... disable `addBreakPoint` and `addBreakOperand` methods
   - `-DZ80_DISABLE_NESTCHECK` ... disable `addCallHandler` and `addReturnHandler` methods
 - The return value of `consumeClock` was returning the number of clocks consumed, but this was changed to `void` because it was redundant.
+- Add the constructor without arguments.
 
 ## Version 1.9.2 (Jan 20, 2023 JST)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - `-DZ80_DISABLE_NESTCHECK` ... disable `addCallHandler` and `addReturnHandler` methods
 - The return value of `consumeClock` was returning the number of clocks consumed, but this was changed to `void` because it was redundant.
 - Add the constructor without arguments.
+- Add an execute method without expected clocks
 
 ## Version 1.9.2 (Jan 20, 2023 JST)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## Version 1.9.3 (Jul 10, 2023 JST)
+
+- Add compile flags for performance:
+  - `-DZ80_DISABLE_DEBUG` ... disable `setDebugMessage` method
+  - `-DZ80_DISABLE_BREAKPOINT` ... disable `addBreakPoint` and `addBreakOperand` methods
+  - `-DZ80_DISABLE_NESTCHECK` ... disable `addCallHandler` and `addReturnHandler` methods
+
 ## Version 1.9.2 (Jan 20, 2023 JST)
 
 - The value of the upper 8 bits of the port number of the immediate I/O operands (`IN A, (n)` and `OUT (n), A`) when executed in 16-bit port mode has been changed from register B to A.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add an execute method without expected clocks
 - optimize acqauire register-pointer and register procedure
 - optimize bit calculation
+- optimize checkConditionFlags
 
 ## Version 1.9.2 (Jan 20, 2023 JST)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - The return value of `consumeClock` was returning the number of clocks consumed, but this was changed to `void` because it was redundant.
 - Add the constructor without arguments.
 - Add an execute method without expected clocks
+- optimize acqauire register-pointer and register procedure
 
 ## Version 1.9.2 (Jan 20, 2023 JST)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - `-DZ80_DISABLE_DEBUG` ... disable `setDebugMessage` method
   - `-DZ80_DISABLE_BREAKPOINT` ... disable `addBreakPoint` and `addBreakOperand` methods
   - `-DZ80_DISABLE_NESTCHECK` ... disable `addCallHandler` and `addReturnHandler` methods
+- The return value of `consumeClock` was returning the number of clocks consumed, but this was changed to `void` because it was redundant.
 
 ## Version 1.9.2 (Jan 20, 2023 JST)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add the constructor without arguments.
 - Add an execute method without expected clocks
 - optimize acqauire register-pointer and register procedure
+- optimize bit calculation
 
 ## Version 1.9.2 (Jan 20, 2023 JST)
 

--- a/README.md
+++ b/README.md
@@ -384,6 +384,14 @@ ReturnHandler will be called back immediately **before** a branch by a RET instr
 - call `addReturnHandlerFP` if you want to use the function pointer.
 - In the case of a condition-specified branch instruction, only the case where the branch is executed is callbacked.
 
+## Advanced Compile Flags
+
+There is a compile flag that disables certain features in order to adapt to environments with poor performance environments, i.e: Arduino or ESP32:
+
+- `-DZ80_DISABLE_DEBUG` ... disable `setDebugMessage` method
+- `-DZ80_DISABLE_BREAKPOINT` ... disable `addBreakPoint` and `addBreakOperand` methods
+- `-DZ80_DISABLE_NESTCHECK` ... disable `addCallHandler` and `addReturnHandler` methods
+
 ## License
 
 [MIT](LICENSE.txt)

--- a/test-ex/Makefile
+++ b/test-ex/Makefile
@@ -6,7 +6,8 @@ COMMON_FLAGS=-I../ \
 	-Wunused-variable \
 	-Wsign-conversion \
 	-Wtype-limits \
-	-Werror
+	-Werror \
+	-DZ80_DISABLE_DEBUG
 
 all: cpm zexdoc zexall
 

--- a/test-ex/cpm.cpp
+++ b/test-ex/cpm.cpp
@@ -90,7 +90,9 @@ int main(int argc, char* argv[])
 {
     char* cimPath = NULL;
     bool checkError = false;
+#ifndef Z80_DISABLE_DEBUG
     bool verboseMode = false;
+#endif
     bool noAnimation = false;
     for (int i = 1; i < argc; i++) {
         if ('-' == argv[i][0]) {
@@ -98,9 +100,11 @@ int main(int argc, char* argv[])
                 case 'e':
                     checkError = true;
                     break;
+#ifndef Z80_DISABLE_DEBUG
                 case 'v':
                     verboseMode = true;
                     break;
+#endif
                 case 'n':
                     noAnimation = true;
                     break;
@@ -131,11 +135,13 @@ int main(int argc, char* argv[])
     z80.addBreakPointFP(0xFF04, [](void* arg) {
         ((CPM*)arg)->halted = true;
     });
+#ifndef Z80_DISABLE_DEBUG
     if (verboseMode) {
         z80.setDebugMessageFP([](void* arg, const char* msg) {
             puts(msg);
         });
     }
+#endif
     cpm.lineCallback = [](CPM* cpmPtr, char* line) {
         if (cpmPtr->checkError && strstr(line, "ERROR")) {
             cpmPtr->halted = true;

--- a/test/Makefile
+++ b/test/Makefile
@@ -67,6 +67,6 @@ test-remove-break:
 	cat test-remove-break.txt
 
 test-checkreg-on-callback:
-	clang $(CFLAGS) test-checkreg-on-callback.cpp -lstdc++
+	clang $(CFLAGS) -DZ80_DISABLE_BREAKPOINT test-checkreg-on-callback.cpp -lstdc++
 	./a.out > test-checkreg-on-callback.txt
 	cat test-checkreg-on-callback.txt

--- a/test/Makefile
+++ b/test/Makefile
@@ -34,7 +34,7 @@ test-unknown:
 	cat test-unknown.txt
 
 test-clock:
-	clang $(CFLAGS) test-clock.cpp -lstdc++
+	clang $(CFLAGS) -DZ80_DISABLE_BREAKPOINT test-clock.cpp -lstdc++
 	./a.out
 
 test-status:
@@ -67,6 +67,6 @@ test-remove-break:
 	cat test-remove-break.txt
 
 test-checkreg-on-callback:
-	clang $(CFLAGS) -DZ80_DISABLE_BREAKPOINT test-checkreg-on-callback.cpp -lstdc++
+	clang $(CFLAGS) test-checkreg-on-callback.cpp -lstdc++
 	./a.out > test-checkreg-on-callback.txt
 	cat test-checkreg-on-callback.txt

--- a/test/Makefile
+++ b/test/Makefile
@@ -34,7 +34,7 @@ test-unknown:
 	cat test-unknown.txt
 
 test-clock:
-	clang $(CFLAGS) -DZ80_DISABLE_BREAKPOINT test-clock.cpp -lstdc++
+	clang $(CFLAGS) -DZ80_DISABLE_BREAKPOINT -DZ80_DISABLE_NESTCHECK test-clock.cpp -lstdc++
 	./a.out
 
 test-status:

--- a/z80.hpp
+++ b/z80.hpp
@@ -102,6 +102,8 @@ class Z80
     }
 
   private: // Internal functions & variables
+    // bit table
+    const unsigned char bits[8] = {0b00000001, 0b00000010, 0b00000100, 0b00001000, 0b00010000, 0b00100000, 0b01000000, 0b10000000};
     // flag setter
     inline void setFlagS(bool on) { on ? reg.pair.F |= flagS() : reg.pair.F &= ~flagS(); }
     inline void setFlagZ(bool on) { on ? reg.pair.F |= flagZ() : reg.pair.F &= ~flagZ(); }
@@ -4313,16 +4315,7 @@ class Z80
         if (isDebug()) log("[%04X] BIT %s of bit-%d", reg.PC - 2, registerDump(r), bit);
 #endif
         unsigned char n = 0;
-        switch (bit) {
-            case 0: n = *rp & 0b00000001; break;
-            case 1: n = *rp & 0b00000010; break;
-            case 2: n = *rp & 0b00000100; break;
-            case 3: n = *rp & 0b00001000; break;
-            case 4: n = *rp & 0b00010000; break;
-            case 5: n = *rp & 0b00100000; break;
-            case 6: n = *rp & 0b01000000; break;
-            case 7: n = *rp & 0b10000000; break;
-        }
+        n = *rp & bits[bit];
         setFlagZ(n ? false : true);
         setFlagPV(isFlagZ());
         setFlagS(!isFlagZ() && 7 == bit);
@@ -4346,16 +4339,7 @@ class Z80
 #ifndef Z80_DISABLE_DEBUG
         if (isDebug()) log("[%04X] BIT (%s) = $%02X of bit-%d", reg.PC - 2, registerPairDump(0b10), n, bit);
 #endif
-        switch (bit) {
-            case 0: n &= 0b00000001; break;
-            case 1: n &= 0b00000010; break;
-            case 2: n &= 0b00000100; break;
-            case 3: n &= 0b00001000; break;
-            case 4: n &= 0b00010000; break;
-            case 5: n &= 0b00100000; break;
-            case 6: n &= 0b01000000; break;
-            case 7: n &= 0b10000000; break;
-        }
+        n &= bits[bit];
         setFlagZ(!n);
         setFlagPV(isFlagZ());
         setFlagS(!isFlagZ() && 7 == bit);
@@ -4379,16 +4363,7 @@ class Z80
 #ifndef Z80_DISABLE_DEBUG
         if (isDebug()) log("[%04X] BIT (IX+d<$%04X>) = $%02X of bit-%d", reg.PC - 4, (unsigned short)(reg.IX + d), n, bit);
 #endif
-        switch (bit) {
-            case 0: n &= 0b00000001; break;
-            case 1: n &= 0b00000010; break;
-            case 2: n &= 0b00000100; break;
-            case 3: n &= 0b00001000; break;
-            case 4: n &= 0b00010000; break;
-            case 5: n &= 0b00100000; break;
-            case 6: n &= 0b01000000; break;
-            case 7: n &= 0b10000000; break;
-        }
+        n &= bits[bit];
         setFlagZ(!n);
         setFlagPV(isFlagZ());
         setFlagS(!isFlagZ() && 7 == bit);
@@ -4412,16 +4387,7 @@ class Z80
 #ifndef Z80_DISABLE_DEBUG
         if (isDebug()) log("[%04X] BIT (IY+d<$%04X>) = $%02X of bit-%d", reg.PC - 4, (unsigned short)(reg.IY + d), n, bit);
 #endif
-        switch (bit) {
-            case 0: n &= 0b00000001; break;
-            case 1: n &= 0b00000010; break;
-            case 2: n &= 0b00000100; break;
-            case 3: n &= 0b00001000; break;
-            case 4: n &= 0b00010000; break;
-            case 5: n &= 0b00100000; break;
-            case 6: n &= 0b01000000; break;
-            case 7: n &= 0b10000000; break;
-        }
+        n &= bits[bit];
         setFlagZ(!n);
         setFlagPV(isFlagZ());
         setFlagS(!isFlagZ() && 7 == bit);
@@ -4493,16 +4459,7 @@ class Z80
 #ifndef Z80_DISABLE_DEBUG
         if (isDebug()) log("[%04X] SET %s of bit-%d", reg.PC - 2, registerDump(r), bit);
 #endif
-        switch (bit) {
-            case 0: *rp |= 0b00000001; break;
-            case 1: *rp |= 0b00000010; break;
-            case 2: *rp |= 0b00000100; break;
-            case 3: *rp |= 0b00001000; break;
-            case 4: *rp |= 0b00010000; break;
-            case 5: *rp |= 0b00100000; break;
-            case 6: *rp |= 0b01000000; break;
-            case 7: *rp |= 0b10000000; break;
-        }
+        *rp |= bits[bit];
     }
 
     // SET bit b of location (HL)
@@ -4521,16 +4478,7 @@ class Z80
 #ifndef Z80_DISABLE_DEBUG
         if (isDebug()) log("[%04X] SET (%s) = $%02X of bit-%d", reg.PC - 2, registerPairDump(0b10), n, bit);
 #endif
-        switch (bit) {
-            case 0: n |= 0b00000001; break;
-            case 1: n |= 0b00000010; break;
-            case 2: n |= 0b00000100; break;
-            case 3: n |= 0b00001000; break;
-            case 4: n |= 0b00010000; break;
-            case 5: n |= 0b00100000; break;
-            case 6: n |= 0b01000000; break;
-            case 7: n |= 0b10000000; break;
-        }
+        n |= bits[bit];
         writeByte(addr, n, 3);
     }
 
@@ -4550,16 +4498,7 @@ class Z80
 #ifndef Z80_DISABLE_DEBUG
         if (isDebug()) log("[%04X] SET (IX+d<$%04X>) = $%02X of bit-%d%s", reg.PC - 4, addr, n, bit, extraLog ? extraLog : "");
 #endif
-        switch (bit) {
-            case 0: n |= 0b00000001; break;
-            case 1: n |= 0b00000010; break;
-            case 2: n |= 0b00000100; break;
-            case 3: n |= 0b00001000; break;
-            case 4: n |= 0b00010000; break;
-            case 5: n |= 0b00100000; break;
-            case 6: n |= 0b01000000; break;
-            case 7: n |= 0b10000000; break;
-        }
+        n |= bits[bit];
         if (rp) *rp = n;
         writeByte(addr, n, 3);
     }
@@ -4653,16 +4592,7 @@ class Z80
 #ifndef Z80_DISABLE_DEBUG
         if (isDebug()) log("[%04X] SET (IY+d<$%04X>) = $%02X of bit-%d%s", reg.PC - 4, addr, n, bit, extraLog ? extraLog : "");
 #endif
-        switch (bit) {
-            case 0: n |= 0b00000001; break;
-            case 1: n |= 0b00000010; break;
-            case 2: n |= 0b00000100; break;
-            case 3: n |= 0b00001000; break;
-            case 4: n |= 0b00010000; break;
-            case 5: n |= 0b00100000; break;
-            case 6: n |= 0b01000000; break;
-            case 7: n |= 0b10000000; break;
-        }
+        n |= bits[bit];
         if (rp) *rp = n;
         writeByte(addr, n, 3);
     }

--- a/z80.hpp
+++ b/z80.hpp
@@ -921,6 +921,7 @@ class Z80
         return 0xFF;
     }
 
+#ifndef Z80_DISABLE_DEBUG
     inline char* registerDump(unsigned char r)
     {
         static char A[16];
@@ -1046,6 +1047,7 @@ class Z80
             default: return unknown;
         }
     }
+#endif
 
     // Load Reg. r1 with Reg. r2
     static inline void LD_B_B(Z80* ctx) { ctx->LD_R1_R2(0b000, 0b000); }

--- a/z80.hpp
+++ b/z80.hpp
@@ -6097,6 +6097,22 @@ class Z80
         initialize();
     }
 
+    Z80()
+    {
+        initialize();
+    }
+
+    void setupCallback(std::function<unsigned char(void*, unsigned short)> read,
+                       std::function<void(void*, unsigned short, unsigned char)> write,
+                       std::function<unsigned char(void*, unsigned short)> in,
+                       std::function<void(void*, unsigned short, unsigned char)> out,
+                       void* arg,
+                       bool returnPortAs16Bits = false)
+    {
+        CB.arg = arg;
+        setupCallback(read, write, in, out, returnPortAs16Bits);
+    }
+
     void setupCallback(std::function<unsigned char(void*, unsigned short)> read,
                        std::function<void(void*, unsigned short, unsigned char)> write,
                        std::function<unsigned char(void*, unsigned short)> in,
@@ -6121,6 +6137,17 @@ class Z80
         CB.in.setupAsFunctionObject(in);
         CB.out.setupAsFunctionObject(out);
         CB.returnPortAs16Bits = returnPortAs16Bits;
+    }
+
+    void setupCallbackFP(unsigned char (*read)(void* arg, unsigned short addr),
+                         void (*write)(void* arg, unsigned short addr, unsigned char value),
+                         unsigned char (*in)(void* arg, unsigned short port),
+                         void (*out)(void* arg, unsigned short port, unsigned char value),
+                         void* arg,
+                         bool returnPortAs16Bits = false)
+    {
+        CB.arg = arg;
+        setupCallbackFP(read, write, in, out, returnPortAs16Bits);
     }
 
     void setupCallbackFP(unsigned char (*read)(void* arg, unsigned short addr),

--- a/z80.hpp
+++ b/z80.hpp
@@ -885,41 +885,9 @@ class Z80
 #endif
     }
 
-    inline unsigned char* getRegisterPointer(unsigned char r)
-    {
-        switch (r) {
-            case 0b111: return &reg.pair.A;
-            case 0b000: return &reg.pair.B;
-            case 0b001: return &reg.pair.C;
-            case 0b010: return &reg.pair.D;
-            case 0b011: return &reg.pair.E;
-            case 0b100: return &reg.pair.H;
-            case 0b101: return &reg.pair.L;
-            case 0b110: return &reg.pair.F;
-        }
-#ifndef Z80_DISABLE_DEBUG
-        if (isDebug()) log("detected an unknown register number: $%02X", r);
-#endif
-        return nullptr;
-    }
-
-    inline unsigned char getRegister(unsigned char r)
-    {
-        switch (r) {
-            case 0b111: return reg.pair.A;
-            case 0b000: return reg.pair.B;
-            case 0b001: return reg.pair.C;
-            case 0b010: return reg.pair.D;
-            case 0b011: return reg.pair.E;
-            case 0b100: return reg.pair.H;
-            case 0b101: return reg.pair.L;
-            case 0b110: return reg.pair.F;
-        }
-#ifndef Z80_DISABLE_DEBUG
-        if (isDebug()) log("detected an unknown register number: $%02X", r);
-#endif
-        return 0xFF;
-    }
+    unsigned char* registerPointerTable[8] = {&reg.pair.B, &reg.pair.C, &reg.pair.D, &reg.pair.E, &reg.pair.H, &reg.pair.L, &reg.pair.F, &reg.pair.A};
+    inline unsigned char* getRegisterPointer(unsigned char r) { return registerPointerTable[r]; }
+    inline unsigned char getRegister(unsigned char r) { return *registerPointerTable[r]; }
 
 #ifndef Z80_DISABLE_DEBUG
     inline char* registerDump(unsigned char r)

--- a/z80.hpp
+++ b/z80.hpp
@@ -740,7 +740,9 @@ class Z80
         unsigned char l = ctx->fetch(3);
         unsigned char h = ctx->fetch(3);
         unsigned short addr = ctx->make16BitsFromLE(l, h);
+#ifndef Z80_DISABLE_DEBUG
         unsigned short hl = ctx->getHL();
+#endif
         ctx->reg.pair.L = ctx->readByte(addr, 3);
         ctx->reg.pair.H = ctx->readByte(addr + 1, 3);
 #ifndef Z80_DISABLE_DEBUG
@@ -797,11 +799,13 @@ class Z80
 
     static inline void EX_SP_HL(Z80* ctx)
     {
+#ifndef Z80_DISABLE_DEBUG
         unsigned short sp = ctx->reg.SP;
+#endif
         unsigned char l = ctx->pop(4);
         unsigned char h = ctx->pop(4);
-        unsigned short hl = ctx->getHL();
 #ifndef Z80_DISABLE_DEBUG
+        unsigned short hl = ctx->getHL();
         if (ctx->isDebug()) ctx->log("[%04X] EX (SP<$%04X>) = $%02X%02X, HL<$%04X>", ctx->reg.PC - 1, sp, h, l, hl);
 #endif
         ctx->push(ctx->reg.pair.H, 4);
@@ -1538,7 +1542,9 @@ class Z80
                 break;
             case 0b11: {
                 // SP is not managed in pair structure, so calculate directly
+#ifndef Z80_DISABLE_DEBUG
                 unsigned short sp = reg.SP;
+#endif
                 setSPL(fetch(3));
                 setSPH(fetch(3));
 #ifndef Z80_DISABLE_DEBUG
@@ -1688,7 +1694,9 @@ class Z80
         unsigned char l = fetch(3);
         unsigned char h = fetch(3);
         unsigned short addr = make16BitsFromLE(l, h);
+#ifndef Z80_DISABLE_DEBUG
         unsigned short ix = reg.IX;
+#endif
         setIXL(readByte(addr, 3));
         setIXH(readByte(addr + 1, 3));
 #ifndef Z80_DISABLE_DEBUG
@@ -1703,7 +1711,9 @@ class Z80
         unsigned char l = fetch(3);
         unsigned char h = fetch(3);
         unsigned short addr = make16BitsFromLE(l, h);
+#ifndef Z80_DISABLE_DEBUG
         unsigned short iy = reg.IY;
+#endif
         setIYL(readByte(addr, 3));
         setIYH(readByte(addr + 1, 3));
 #ifndef Z80_DISABLE_DEBUG
@@ -1807,7 +1817,9 @@ class Z80
     static inline void EX_SP_IX_(Z80* ctx) { ctx->EX_SP_IX(); }
     inline void EX_SP_IX()
     {
+#ifndef Z80_DISABLE_DEBUG
         unsigned short sp = reg.SP;
+#endif
         unsigned char l = pop(4);
         unsigned char h = pop(4);
 #ifndef Z80_DISABLE_DEBUG
@@ -1823,7 +1835,9 @@ class Z80
     static inline void EX_SP_IY_(Z80* ctx) { ctx->EX_SP_IY(); }
     inline void EX_SP_IY()
     {
+#ifndef Z80_DISABLE_DEBUG
         unsigned short sp = reg.SP;
+#endif
         unsigned char l = pop(4);
         unsigned char h = pop(4);
 #ifndef Z80_DISABLE_DEBUG
@@ -1871,26 +1885,32 @@ class Z80
     static inline void POP_HL(Z80* ctx) { ctx->POP_RP(0b10); }
     inline void POP_RP(unsigned char rp)
     {
-        unsigned short sp = reg.SP;
 #ifndef Z80_DISABLE_DEBUG
+        unsigned short sp = reg.SP;
         const char* dump = isDebug() ? registerPairDump(rp) : "";
-#endif
         unsigned short after;
+#endif
         switch (rp) {
             case 0b00:
                 reg.pair.C = pop(3);
                 reg.pair.B = pop(3);
+#ifndef Z80_DISABLE_DEBUG
                 after = getBC();
+#endif
                 break;
             case 0b01:
                 reg.pair.E = pop(3);
                 reg.pair.D = pop(3);
+#ifndef Z80_DISABLE_DEBUG
                 after = getDE();
+#endif
                 break;
             case 0b10:
                 reg.pair.L = pop(3);
                 reg.pair.H = pop(3);
+#ifndef Z80_DISABLE_DEBUG
                 after = getHL();
+#endif
                 break;
             default:
 #ifndef Z80_DISABLE_DEBUG
@@ -1919,7 +1939,9 @@ class Z80
     static inline void POP_IX_(Z80* ctx) { ctx->POP_IX(); }
     inline void POP_IX()
     {
+#ifndef Z80_DISABLE_DEBUG
         unsigned short sp = reg.SP;
+#endif
         setIXL(pop(3));
         setIXH(pop(3));
 #ifndef Z80_DISABLE_DEBUG
@@ -1942,7 +1964,9 @@ class Z80
     static inline void POP_IY_(Z80* ctx) { ctx->POP_IY(); }
     inline void POP_IY()
     {
+#ifndef Z80_DISABLE_DEBUG
         unsigned short sp = reg.SP;
+#endif
         setIYL(pop(3));
         setIYH(pop(3));
 #ifndef Z80_DISABLE_DEBUG
@@ -5303,8 +5327,8 @@ class Z80
     static inline void RET(Z80* ctx)
     {
         ctx->invokeReturnHandlers();
-        unsigned short pc = ctx->reg.PC - 1;
 #ifndef Z80_DISABLE_DEBUG
+        unsigned short pc = ctx->reg.PC - 1;
         const char* dump = ctx->isDebug() ? ctx->registerPairDump(0b11) : "";
 #endif
         ctx->setPCL(ctx->pop(3));
@@ -5361,8 +5385,10 @@ class Z80
             return;
         }
         invokeReturnHandlers();
+#ifndef Z80_DISABLE_DEBUG
         unsigned short pc = reg.PC;
         unsigned short sp = reg.SP;
+#endif
         setPCL(pop(4));
         setPCH(pop(3));
         reg.WZ = reg.PC;
@@ -5376,8 +5402,10 @@ class Z80
     inline void RETI()
     {
         invokeReturnHandlers();
+#ifndef Z80_DISABLE_DEBUG
         unsigned short pc = reg.PC;
         unsigned short sp = reg.SP;
+#endif
         setPCL(pop(3));
         setPCH(pop(3));
         reg.WZ = reg.PC;
@@ -5392,8 +5420,10 @@ class Z80
     inline void RETN()
     {
         invokeReturnHandlers();
+#ifndef Z80_DISABLE_DEBUG
         unsigned short pc = reg.PC;
         unsigned short sp = reg.SP;
+#endif
         setPCL(pop(3));
         setPCH(pop(3));
         reg.WZ = reg.PC;
@@ -5424,8 +5454,10 @@ class Z80
     inline void RST(unsigned char t, bool isOperand)
     {
         unsigned short addr = t * 8;
+#ifndef Z80_DISABLE_DEBUG
         unsigned short sp = reg.SP;
         unsigned short pc = reg.PC;
+#endif
         push(getPCH(), 4);
         setPCH(0);
         push(getPCL(), 3);
@@ -5624,7 +5656,9 @@ class Z80
         unsigned char nL = beforeN & 0b00001111;
         unsigned char aH = (reg.pair.A & 0b11110000) >> 4;
         unsigned char aL = reg.pair.A & 0b00001111;
+#ifndef Z80_DISABLE_DEBUG
         unsigned char beforeA = reg.pair.A;
+#endif
         unsigned char afterA = (aH << 4) | nH;
         unsigned char afterN = (nL << 4) | aL;
 #ifndef Z80_DISABLE_DEBUG
@@ -5651,7 +5685,9 @@ class Z80
         unsigned char nL = beforeN & 0b00001111;
         unsigned char aH = (reg.pair.A & 0b11110000) >> 4;
         unsigned char aL = reg.pair.A & 0b00001111;
+#ifndef Z80_DISABLE_DEBUG
         unsigned char beforeA = reg.pair.A;
+#endif
         unsigned char afterA = (aH << 4) | nL;
         unsigned char afterN = (aL << 4) | nH;
 #ifndef Z80_DISABLE_DEBUG

--- a/z80.hpp
+++ b/z80.hpp
@@ -482,11 +482,10 @@ class Z80
         return (on & 1) == 0;
     }
 
-    inline int consumeClock(int hz)
+    inline void consumeClock(int hz)
     {
         reg.consumeClockCounter += hz;
         if (CB.consumeClockEnabled && hz) CB.consumeClock(CB.arg, hz);
-        return hz;
     }
 
     inline unsigned short getPort16WithB(unsigned char c) { return make16BitsFromLE(c, reg.pair.B); }

--- a/z80.hpp
+++ b/z80.hpp
@@ -270,7 +270,9 @@ class Z80
 #endif
         CoExistenceCallback<void(void*, int)> consumeClock;
         bool consumeClockEnabled;
+#ifndef Z80_DISABLE_BREAKPOINT
         std::map<int, std::vector<BreakPoint*>*> breakPoints;
+#endif
         std::map<int, std::vector<BreakOperand*>*> breakOperands;
         std::vector<SimpleHandler*> returnHandlers;
         std::vector<SimpleHandler*> callHandlers;
@@ -279,6 +281,7 @@ class Z80
 
     bool requestBreakFlag;
 
+#ifndef Z80_DISABLE_BREAKPOINT
     inline void checkBreakPoint()
     {
         auto it = CB.breakPoints.find(reg.PC);
@@ -287,6 +290,7 @@ class Z80
             bp->callback(CB.arg);
         }
     }
+#endif
 
     inline void readFullOpcode(BreakOperand* operand, unsigned char* opcode, int* opcodeLength)
     {
@@ -6124,7 +6128,9 @@ class Z80
     ~Z80()
     {
         removeAllBreakOperands();
+#ifndef Z80_DISABLE_BREAKPOINT
         removeAllBreakPoints();
+#endif
         removeAllCallHandlers();
         removeAllReturnHandlers();
     }
@@ -6169,6 +6175,7 @@ class Z80
         *low = value & 0xFF;
     }
 
+#ifndef Z80_DISABLE_BREAKPOINT
     template <typename Functor>
     void addBreakPoint(unsigned short addr, Functor callback)
     {
@@ -6208,6 +6215,7 @@ class Z80
             removeBreakPoint(key);
         }
     }
+#endif
 
     void addBreakOperand_(int prefixNumber, int operandNumber, const std::function<void(void*, unsigned char*, int)>& callback)
     {
@@ -6378,7 +6386,9 @@ class Z80
                 readByte(reg.PC); // NOTE: read and discard (to be consumed 4Hz)
             } else {
                 if (wtc.fetch) consumeClock(wtc.fetch);
+#ifndef Z80_DISABLE_BREAKPOINT
                 checkBreakPoint();
+#endif
                 reg.execEI = 0;
                 int operandNumber = fetch(2);
                 updateRefreshRegister();


### PR DESCRIPTION
Add compile flags to disable certain features in order to adapt to environments with severe performance requirements.

- Add compile flags for performance:
  - [x] `-DZ80_DISABLE_DEBUG` ... disable `setDebugMessage` method
  - [x] `-DZ80_DISABLE_BREAKPOINT` ... disable `addBreakPoint` and `addBreakOperand` methods
  - [x] `-DZ80_DISABLE_NESTCHECK` ... disable `addCallHandler` and `addReturnHandler` methods
- Optimization
  - [x] optimize acqauire register-pointer and register procedure
  - [x] optimize bit calculation
  - [x] optimize checkConditionFlags
- [x] The return value of `consumeClock` was returning the number of clocks consumed, but this was changed to `void` because it was redundant.
- [x] Add the constructor without arguments.
- [x] Add an execute method without expected clocks
